### PR TITLE
feat: Redesign PDF generation and fix critical bugs

### DIFF
--- a/services/crosswordGenerator.ts
+++ b/services/crosswordGenerator.ts
@@ -196,8 +196,8 @@ export const generateCrosswordLayout = (words: WordInput[], gridSize: number = 2
     }
     if(tempPlacedWords.length === 0) return null;
 
-    const { clues, finalPlacedWords } = assignNumbersAndGenerateClues(grid, tempPlacedWords);
     finalizeGrid(grid);
+    const { clues, finalPlacedWords } = assignNumbersAndGenerateClues(grid, tempPlacedWords);
 
     return { grid, clues, placedWords: finalPlacedWords };
 };


### PR DESCRIPTION
This commit completely redesigns the PDF generation functionality and fixes two critical bugs that arose during development.

Features:
- PDF page size is now A5.
- The crossword grid and clues are now on the same page.
- You can now choose to generate the PDF with or without the solution.
- The grid is now compact, removing empty space around the puzzle.
- The layout has a more elegant and print-friendly black-and-white design.

Bug Fixes:
- Fixed a bug where across and down clues starting at the same cell were assigned the same number. The numbering logic is now compliant with standard crossword conventions.
- Fixed a regression where the grid would fail to generate after the clue numbering logic was updated. This was caused by an incorrect order of operations.