### PR TITLE
Redesenha interface com menu e PDF A5

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import PlayerGrid from './components/PlayerGrid';
 import GameOverModal from './components/GameOverModal';
 import SettingsModal from './components/SettingsModal';
 import GameMenu from './components/GameMenu';
+import MainMenu from './components/MainMenu';
 
 // Icons
 const TrashIcon = () => (<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-red-500 hover:text-red-700"><path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /><line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" /></svg>);
@@ -43,6 +44,9 @@ export default function App() {
     const [showSolution, setShowSolution] = useState(false);
     const [apiKey, setApiKey] = useState(() => sessionStorage.getItem('gemini-api-key') || '');
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+
+    // Navigation
+    const [page, setPage] = useState<'menu' | 'editor' | 'player'>('menu');
 
     // Player State
     const [isPlaying, setIsPlaying] = useState(false);
@@ -86,6 +90,7 @@ export default function App() {
         setIsGameOver(false);
         resetPlayerState();
         setIsPlaying(true);
+        setPage('player');
     };
 
     const handlePlayTimedMode = () => {
@@ -96,11 +101,13 @@ export default function App() {
         setIsGameOver(false);
         resetPlayerState();
         setIsPlaying(true);
+        setPage('player');
     };
 
     const handleBackToEditor = () => {
         setIsPlaying(false);
         setIsTimerRunning(false);
+        setPage('editor');
     };
 
     const handleCloseModal = () => {
@@ -221,6 +228,7 @@ export default function App() {
                 setIsPlaying(false);
                 setError(null);
                 toast.success("Jogo carregado com sucesso!");
+                setPage('editor');
 
             } catch (err) {
                 const errorMessage = err instanceof Error ? err.message : "Erro ao carregar o arquivo.";
@@ -352,14 +360,11 @@ export default function App() {
 
     const renderEditor = () => (
         <main className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            <SettingsModal
-                isOpen={isSettingsOpen}
-                onClose={() => setIsSettingsOpen(false)}
-                apiKey={apiKey}
-                onApiKeyChange={setApiKey}
-            />
+            <button onClick={() => setPage('menu')} className="lg:col-span-3 mb-4 text-sm text-blue-600 flex items-center gap-1">
+                ← Menu
+            </button>
             <div className="lg:col-span-1">
-                 <GameMenu
+                <GameMenu
                     onGenerateWithAI={handleGenerateWithGemini}
                     onAddWordsManually={() => { /* For future use */ }}
                     onLoadGame={handleLoadClick}
@@ -442,6 +447,9 @@ export default function App() {
 
     const renderPlayer = () => (
         <main className="flex flex-col lg:grid lg:grid-cols-3 gap-8">
+            <button onClick={() => setPage('menu')} className="mb-4 text-sm text-blue-600 lg:col-span-3 flex items-center gap-1">
+                ← Menu
+            </button>
             <div className="lg:col-span-1 bg-white p-6 rounded-xl shadow-lg flex flex-col h-fit lg:order-2">
                 <h2 className="text-2xl font-bold mb-1">Modo de Jogo</h2>
                 <p className="text-gray-600 mb-4 text-sm">Tema: {theme}</p>
@@ -502,27 +510,43 @@ export default function App() {
     )
 
     return (
-        <div className="container mx-auto p-4 md:p-8">
+        <div className="min-h-screen">
             <Toaster position="top-center" />
-            <header className="text-center mb-10">
-                <h1 className="text-4xl md:text-5xl font-extrabold text-gray-800">
-                    Gerador de Palavras Cruzadas
-                </h1>
-                <p className="text-lg text-gray-600 mt-2">Crie, jogue e imprima suas palavras cruzadas</p>
-            </header>
-            
-            {isPlaying ? renderPlayer() : renderEditor()}
+            <input type="file" ref={fileInputRef} onChange={handleFileChange} accept="application/json" className="hidden" />
+            <SettingsModal
+                isOpen={isSettingsOpen}
+                onClose={() => setIsSettingsOpen(false)}
+                apiKey={apiKey}
+                onApiKeyChange={setApiKey}
+            />
+            {page === 'menu' ? (
+                <MainMenu
+                    onStart={() => { setWords([]); setGridData(null); setPage('editor'); }}
+                    onLoadGame={handleLoadClick}
+                    onOpenSettings={() => setIsSettingsOpen(true)}
+                />
+            ) : (
+                <div className="container mx-auto p-4 md:p-8">
+                    <header className="text-center mb-10">
+                        <h1 className="text-4xl md:text-5xl font-extrabold text-gray-800">
+                            Gerador de Palavras Cruzadas
+                        </h1>
+                        <p className="text-lg text-gray-600 mt-2">Crie, jogue e imprima suas palavras cruzadas</p>
+                    </header>
 
+                    {page === 'player' ? renderPlayer() : renderEditor()}
+
+                     <footer className="text-center mt-12 text-gray-500 text-sm">
+                        <p>Desenvolvido com React, TypeScript, Tailwind CSS e a API Google Gemini.</p>
+                    </footer>
+                </div>
+            )}
             <GameOverModal
                 isOpen={showGameOverModal}
                 onClose={handleCloseModal}
                 status={gameStatus}
                 timeLeft={timeLeft}
             />
-
-             <footer className="text-center mt-12 text-gray-500 text-sm">
-                <p>Desenvolvido com React, TypeScript, Tailwind CSS e a API Google Gemini.</p>
-            </footer>
         </div>
     );
 }

--- a/components/MainMenu.tsx
+++ b/components/MainMenu.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface MainMenuProps {
+    onStart: () => void;
+    onLoadGame: () => void;
+    onOpenSettings: () => void;
+}
+
+const MainMenu: React.FC<MainMenuProps> = ({ onStart, onLoadGame, onOpenSettings }) => {
+    return (
+        <div className="flex flex-col items-center justify-center h-screen gap-6 bg-gradient-to-b from-indigo-500 to-purple-600 text-white p-4">
+            <h1 className="text-5xl font-extrabold mb-8 text-center drop-shadow">Palavras Cruzadas</h1>
+            <button onClick={onStart} className="w-64 bg-white text-indigo-700 font-bold py-3 rounded-lg shadow hover:bg-gray-100 transition">
+                Novo Jogo
+            </button>
+            <button onClick={onLoadGame} className="w-64 bg-white text-indigo-700 font-bold py-3 rounded-lg shadow hover:bg-gray-100 transition">
+                Carregar Jogo
+            </button>
+            <button onClick={onOpenSettings} className="w-64 bg-white text-indigo-700 font-bold py-3 rounded-lg shadow hover:bg-gray-100 transition">
+                Configurações
+            </button>
+        </div>
+    );
+};
+
+export default MainMenu;

--- a/services/pdfGenerator.ts
+++ b/services/pdfGenerator.ts
@@ -42,21 +42,27 @@ const createCompactGrid = (grid: GridCell[][]): GridCell[][] => {
 
 
 // Helper to draw the grid
-const drawGrid = (doc: jsPDF, grid: GridCell[][], startY: number, showSolution: boolean) => {
-    const gridSize = grid.length;
-    const gridColSize = grid[0].length;
+const drawGrid = (
+    doc: jsPDF,
+    grid: GridCell[][],
+    startY: number,
+    showSolution: boolean,
+    reserveClueSpace = true
+) => {
+    const rows = grid.length;
+    const cols = grid[0].length;
     const availableWidth = A5_WIDTH - MARGIN * 2;
-    // Make cell size dependent on the larger dimension to maintain aspect ratio
-    const cellSize = availableWidth / Math.max(gridSize, gridColSize);
-    const totalGridWidth = gridColSize * cellSize;
+    const maxHeight = (reserveClueSpace ? A5_HEIGHT - MARGIN - 80 : A5_HEIGHT - MARGIN) - startY;
+    const cellSize = Math.min(availableWidth / cols, maxHeight / rows);
+    const totalGridWidth = cols * cellSize;
     const startX = (A5_WIDTH - totalGridWidth) / 2; // Center the grid horizontally
 
     doc.setDrawColor(100, 100, 100); // Darker gray for lines
     doc.setTextColor(0, 0, 0);
     doc.setLineWidth(0.2);
 
-    for (let r = 0; r < gridSize; r++) {
-        for (let c = 0; c < gridColSize; c++) {
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
             const cell = grid[r][c];
             const x = startX + c * cellSize;
             const y = startY + r * cellSize;
@@ -80,7 +86,7 @@ const drawGrid = (doc: jsPDF, grid: GridCell[][], startY: number, showSolution: 
             }
         }
     }
-    return startY + gridSize * cellSize;
+    return startY + rows * cellSize;
 };
 
 // Helper to draw clues with dynamic font size
@@ -151,7 +157,7 @@ export const generateCrosswordPdf = (gridData: GridData, theme: string, includeS
         doc.setFont('helvetica', 'normal');
 
         // Draw the compact grid
-        const gridEndY = drawGrid(doc, compactGrid, MARGIN + 12, false);
+        const gridEndY = drawGrid(doc, compactGrid, MARGIN + 12, false, true);
 
         // Draw the clues below the grid on the same page
         const cluesStartY = gridEndY + 7;
@@ -166,7 +172,7 @@ export const generateCrosswordPdf = (gridData: GridData, theme: string, includeS
             doc.setFont('helvetica', 'normal');
 
             // Draw the compact grid with the solution
-            drawGrid(doc, compactGrid, MARGIN + 12, true);
+            drawGrid(doc, compactGrid, MARGIN + 12, true, false);
         }
 
         const sanitizedTheme = theme.trim().toLowerCase().replace(/[^a-z0-9]/g, '_') || 'palavras_cruzadas';


### PR DESCRIPTION
## Summary
- Adiciona tela inicial de menu com botões para iniciar, carregar jogo e abrir configurações
- Reestrutura navegação entre menu, editor e jogador dentro do App
- Ajusta gerador de PDF para layout A5 com grade compacta e página opcional de solução

## Testing
- `npm test` *(falhou: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68915e4d6914832dbf6d89f62c0cc9c3