### PR TITLE
Refatora geração de PDF para página única

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     "react/": "https://esm.sh/react@^19.1.0/",
     "@google/genai": "https://esm.sh/@google/genai@^1.8.0",
     "jspdf": "https://esm.sh/jspdf@^2.5.1",
-    "jspdf-autotable": "https://esm.sh/jspdf-autotable@^3.8.2",
     "react-hot-toast": "https://esm.sh/react-hot-toast@^2.4.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@google/genai": "^1.8.0",
         "jspdf": "^2.5.1",
-        "jspdf-autotable": "^3.8.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.4.1"
@@ -1182,15 +1181,6 @@
         "core-js": "^3.6.0",
         "dompurify": "^2.5.4",
         "html2canvas": "^1.0.0-rc.5"
-      }
-    },
-    "node_modules/jspdf-autotable": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-3.8.4.tgz",
-      "integrity": "sha512-rSffGoBsJYX83iTRv8Ft7FhqfgEL2nLpGAIiqruEQQ3e4r0qdLFbPUB7N9HAle0I3XgpisvyW751VHCqKUVOgQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "jspdf": "^2.5.1"
       }
     },
     "node_modules/jwa": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "@google/genai": "^1.8.0",
     "jspdf": "^2.5.1",
-    "jspdf-autotable": "^3.8.2",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Resumo
- Reimplementa gerador de PDF sem `jspdf-autotable`.
- Desenha grade e dicas manualmente em uma única página A5.
- Remove dependência `jspdf-autotable` e atualiza importmap.

## Testes
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689162eec354832d871a81299237afa0