### PR TITLE
feat: add branded style

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { BRAND_NAME, BRAND_TAGLINE } from './brand';
 import { Toaster, toast } from 'react-hot-toast';
 import type { WordInput, GridData, GridCell, ValidationState, Clue, PlacedWord, SavedGame } from './types';
 import { generateCrosswordLayout } from './services/crosswordGenerator';
@@ -534,10 +535,10 @@ export default function App() {
             ) : (
                 <div className="container mx-auto p-4 md:p-8">
                     <header className="text-center mb-10">
-                        <h1 className="text-4xl md:text-5xl font-extrabold text-gray-800">
-                            Gerador de Palavras Cruzadas
+                        <h1 className="text-4xl md:text-5xl font-extrabold brand-title">
+                            {BRAND_NAME}
                         </h1>
-                        <p className="text-lg text-gray-600 mt-2">Crie, jogue e imprima suas palavras cruzadas</p>
+                        <p className="text-lg text-gray-600 mt-2">{BRAND_TAGLINE}</p>
                     </header>
 
                     {page === 'player' ? renderPlayer() : renderEditor()}

--- a/brand.ts
+++ b/brand.ts
@@ -1,0 +1,3 @@
+export const BRAND_NAME = 'Cruzadex';
+export const BRAND_TAGLINE = 'Seu caderninho de palavras cruzadas';
+export const BRAND_PRIMARY_COLOR = [63, 81, 181]; // RGB for #3F51B5

--- a/components/MainMenu.tsx
+++ b/components/MainMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BRAND_NAME } from '../brand';
 
 interface MainMenuProps {
     onStart: () => void;
@@ -8,15 +9,15 @@ interface MainMenuProps {
 
 const MainMenu: React.FC<MainMenuProps> = ({ onStart, onLoadGame, onOpenSettings }) => {
     return (
-        <div className="flex flex-col items-center justify-center h-screen gap-6 bg-gradient-to-b from-indigo-500 to-purple-600 text-white p-4">
-            <h1 className="text-5xl font-extrabold mb-8 text-center drop-shadow">Palavras Cruzadas</h1>
-            <button onClick={onStart} className="w-64 bg-white text-indigo-700 font-bold py-3 rounded-lg shadow hover:bg-gray-100 transition">
+        <div className="flex flex-col items-center justify-center h-screen gap-6 brand-bg text-white p-4">
+            <h1 className="text-5xl font-extrabold mb-8 text-center drop-shadow brand-title">{BRAND_NAME}</h1>
+            <button onClick={onStart} className="w-64 brand-button font-bold py-3 rounded-lg shadow">
                 Novo Jogo
             </button>
-            <button onClick={onLoadGame} className="w-64 bg-white text-indigo-700 font-bold py-3 rounded-lg shadow hover:bg-gray-100 transition">
+            <button onClick={onLoadGame} className="w-64 brand-button font-bold py-3 rounded-lg shadow">
                 Carregar Jogo
             </button>
-            <button onClick={onOpenSettings} className="w-64 bg-white text-indigo-700 font-bold py-3 rounded-lg shadow hover:bg-gray-100 transition">
+            <button onClick={onOpenSettings} className="w-64 brand-button font-bold py-3 rounded-lg shadow">
                 Configurações
             </button>
         </div>

--- a/index.css
+++ b/index.css
@@ -1,0 +1,30 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
+
+:root {
+  --brand-primary: #3f51b5; /* Indigo 600 */
+  --brand-secondary: #6366f1; /* Indigo 500 */
+  --brand-bg: #f9fafb;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background-color: var(--brand-bg);
+}
+
+.brand-bg {
+  background: linear-gradient(to bottom, var(--brand-primary), var(--brand-secondary));
+}
+
+.brand-title {
+  color: var(--brand-primary);
+}
+
+.brand-button {
+  background-color: var(--brand-primary);
+  color: #fff;
+  transition: background-color 0.2s ease;
+}
+
+.brand-button:hover {
+  background-color: var(--brand-secondary);
+}

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 </script>
 <link rel="stylesheet" href="/index.css">
 </head>
-  <body class="bg-gray-50 font-sans text-gray-900">
+  <body class="text-gray-900">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/services/pdfGenerator.ts
+++ b/services/pdfGenerator.ts
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import type { GridData, GridCell, Clue } from '../types';
+import { BRAND_NAME, BRAND_PRIMARY_COLOR } from '../brand';
 
 const A5_WIDTH = 148;
 const A5_HEIGHT = 210;
@@ -163,12 +164,16 @@ export const generateCrosswordPdf = (
     const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a5' });
     const compactGrid = createCompactGrid(gridData.grid);
 
-    doc.setFontSize(16);
+    doc.setFontSize(18);
     doc.setFont('helvetica', 'bold');
-    doc.text(theme.toUpperCase(), A5_WIDTH / 2, MARGIN + 5, { align: 'center' });
+    doc.setTextColor(...BRAND_PRIMARY_COLOR);
+    doc.text(BRAND_NAME.toUpperCase(), A5_WIDTH / 2, MARGIN + 5, { align: 'center' });
+    doc.setTextColor(0, 0, 0);
+    doc.setFontSize(16);
+    doc.text(theme.toUpperCase(), A5_WIDTH / 2, MARGIN + 14, { align: 'center' });
     doc.setFont('helvetica', 'normal');
 
-    const gridStartY = MARGIN + 12;
+    const gridStartY = MARGIN + 20;
     const gridBottom = drawGrid(doc, compactGrid, gridStartY, includeSolution);
     const cluesStartY = gridBottom + 5;
     const availableHeight = A5_HEIGHT - cluesStartY - MARGIN;


### PR DESCRIPTION
## Summary
- add shared brand constants and custom font styling
- use brand colors and title in main menu and header
- brand PDF export with colored header

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6891655de0cc832dbcae8a6e02ea782d