### PR TITLE
Trim unused grid edges for cleaner output

### DIFF
--- a/services/crosswordGenerator.ts
+++ b/services/crosswordGenerator.ts
@@ -1,4 +1,5 @@
 import type { WordInput, GridCell, PlacedWord, Clue, GridData } from '../types';
+import { createCompactGrid } from './gridUtils';
 
 const canPlaceWord = (word: string, row: number, col: number, direction: 'across' | 'down', grid: GridCell[][]): boolean => {
     const len = word.length;
@@ -201,7 +202,13 @@ export const generateCrosswordLayout = (words: WordInput[], gridSize: number = 2
     if(tempPlacedWords.length === 0) return null;
 
     finalizeGrid(grid);
-    const { clues, finalPlacedWords } = assignNumbersAndGenerateClues(grid, tempPlacedWords);
+    const { grid: compactGrid, rowOffset, colOffset } = createCompactGrid(grid);
+    const adjustedPlacedWords = tempPlacedWords.map(p => ({
+        ...p,
+        row: p.row - rowOffset,
+        col: p.col - colOffset,
+    }));
+    const { clues, finalPlacedWords } = assignNumbersAndGenerateClues(compactGrid, adjustedPlacedWords);
 
-    return { grid, clues, placedWords: finalPlacedWords };
+    return { grid: compactGrid, clues, placedWords: finalPlacedWords };
 };

--- a/services/gridUtils.ts
+++ b/services/gridUtils.ts
@@ -1,0 +1,32 @@
+import type { GridCell } from '../types';
+
+export const createCompactGrid = (
+  grid: GridCell[][]
+): { grid: GridCell[][]; rowOffset: number; colOffset: number } => {
+  let minRow = grid.length,
+    maxRow = -1,
+    minCol = grid[0].length,
+    maxCol = -1;
+
+  grid.forEach((row, r) => {
+    row.forEach((cell, c) => {
+      if (!cell.isBlocker) {
+        if (r < minRow) minRow = r;
+        if (r > maxRow) maxRow = r;
+        if (c < minCol) minCol = c;
+        if (c > maxCol) maxCol = c;
+      }
+    });
+  });
+
+  if (maxRow === -1) {
+    return { grid: [], rowOffset: 0, colOffset: 0 };
+  }
+
+  const compactGrid: GridCell[][] = [];
+  for (let r = minRow; r <= maxRow; r++) {
+    compactGrid.push(grid[r].slice(minCol, maxCol + 1));
+  }
+
+  return { grid: compactGrid, rowOffset: minRow, colOffset: minCol };
+};

--- a/services/pdfGenerator.ts
+++ b/services/pdfGenerator.ts
@@ -1,43 +1,13 @@
 import jsPDF from 'jspdf';
 import type { GridData, GridCell, Clue } from '../types';
 import { BRAND_NAME, BRAND_PRIMARY_COLOR } from '../brand';
+import { createCompactGrid } from './gridUtils';
 
 const A5_WIDTH = 148;
 const A5_HEIGHT = 210;
 const MARGIN = 10;
 const GRID_MAX_HEIGHT = 90; // leave room for clues
 const COLUMN_GAP = 5;
-
-const createCompactGrid = (grid: GridCell[][]): GridCell[][] => {
-  let minRow = grid.length, maxRow = -1, minCol = grid[0].length, maxCol = -1;
-
-  grid.forEach((row, r) => {
-    row.forEach((cell, c) => {
-      if (!cell.isBlocker) {
-        if (r < minRow) minRow = r;
-        if (r > maxRow) maxRow = r;
-        if (c < minCol) minCol = c;
-        if (c > maxCol) maxCol = c;
-      }
-    });
-  });
-
-  if (maxRow === -1) {
-    return [[{ char: null, isBlocker: true, number: null }]];
-  }
-
-  minRow = Math.max(0, minRow - 1);
-  maxRow = Math.min(grid.length - 1, maxRow + 1);
-  minCol = Math.max(0, minCol - 1);
-  maxCol = Math.min(grid[0].length - 1, maxCol + 1);
-
-  const compactGrid: GridCell[][] = [];
-  for (let r = minRow; r <= maxRow; r++) {
-    compactGrid.push(grid[r].slice(minCol, maxCol + 1));
-  }
-
-  return compactGrid;
-};
 
 const drawGrid = (
   doc: jsPDF,
@@ -162,7 +132,7 @@ export const generateCrosswordPdf = (
 ): void => {
   try {
     const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a5' });
-    const compactGrid = createCompactGrid(gridData.grid);
+    const { grid: compactGrid } = createCompactGrid(gridData.grid);
 
     doc.setFontSize(18);
     doc.setFont('helvetica', 'bold');


### PR DESCRIPTION
## Summary
- Ensure crossword grid data is cropped to the active puzzle area
- Share compact grid utility for both online play and PDF generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68916ca37984832d9a92d438a5dc776b